### PR TITLE
Move map center to pickup location on order submit

### DIFF
--- a/src/components/Map.jsx
+++ b/src/components/Map.jsx
@@ -55,7 +55,7 @@ Map.propTypes = {
   history: PropTypes.object.isRequired,
   onMoveEnd: PropTypes.func.isRequired,
   orderStage: PropTypes.string.isRequired,
-  orderPickupCoords: PropTypes.object.isRequired
+  orderPickupCoords: PropTypes.object
 };
 
 export default Map;

--- a/src/components/Map.jsx
+++ b/src/components/Map.jsx
@@ -15,7 +15,7 @@ class Map extends Component {
 
     if(this.props.orderStage === 'draft' && nextProps.orderStage === 'searching')
     {
-      initiateZoomTransition(this.map, 15, 14);
+      initiateZoomTransition(this.map, 15, 14, nextProps.orderPickupCoords);
     }
 
     return false;
@@ -54,7 +54,8 @@ Map.propTypes = {
   coords: PropTypes.object.isRequired,
   history: PropTypes.object.isRequired,
   onMoveEnd: PropTypes.func.isRequired,
-  orderStage: PropTypes.string.isRequired
+  orderStage: PropTypes.string.isRequired,
+  orderPickupCoords: PropTypes.object.isRequired
 };
 
 export default Map;

--- a/src/components/OrderScreen.jsx
+++ b/src/components/OrderScreen.jsx
@@ -17,6 +17,7 @@ class OrderScreen extends Component {
     super(props);
     this.updateStoreFromForm = this.updateStoreFromForm.bind(this);
     this.submitForm = this.submitForm.bind(this);
+    this.createOrderDetailsObject = this.createOrderDetailsObject.bind(this);
 
     this.state = {
       packageSize: ''
@@ -41,8 +42,13 @@ class OrderScreen extends Component {
   }
 
   createOrderDetailsObject() {
+    const { userCoords } = this.props;
+
     return {
-      pickup: coordsFromString(this.pickupNode.value),
+      pickup: coordsFromString(this.pickupNode.value) || {
+        lat: userCoords.lat,
+        long: userCoords.long
+      },
       dropoff: coordsFromString(this.dropoffNode.value),
       size: this.state.packageSize || undefined,
       weight: this.weightNode.value || undefined,
@@ -56,14 +62,9 @@ class OrderScreen extends Component {
   }
 
   submitForm() {
-    const { userCoords, createRequest } = this.props;
     this.updateStoreFromForm({ stage: 'searching' });
     let requestDetails = this.createOrderDetailsObject();
-    requestDetails.pickup = requestDetails.pickup || {
-      lat: userCoords.lat,
-      long: userCoords.long
-    };
-    createRequest(requestDetails);
+    this.props.createRequest(requestDetails);
   }
 
   selectPackageSize(size) {

--- a/src/containers/MapContainer.jsx
+++ b/src/containers/MapContainer.jsx
@@ -24,7 +24,8 @@ export default connect(
 
     return {
       vehicles,
-      orderStage: state.order.stage
+      orderStage: state.order.stage,
+      orderPickupCoords: state.order.pickup,
     };
   },
   mapDispatchToProps

--- a/src/lib/map.js
+++ b/src/lib/map.js
@@ -116,9 +116,10 @@ const handleMapUpdate = (map, update) => {
   }
 };
 
-export const initiateZoomTransition = (map, startZoomLevel, endZoomLevel) => {
+export const initiateZoomTransition = (map, startZoomLevel, endZoomLevel, location) => {
   handleMapUpdate(map, () => {
     map.setZoom(startZoomLevel);
+    map.setCenter([location.long, location.lat]);
 
     map.flyTo({
       center: map.center,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When a user submits the order form and the application starts searching for available drones the map is now focused on the pickup location.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#19 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Tested in Chrome 61.0.3163.100

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
