### PR TITLE
Send user_id with every request to mission control

### DIFF
--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -4,7 +4,6 @@ import { getShortCoordsString } from '../lib/utils';
 const apiRoot = process.env.MISSION_CONTROL_HOST;
 
 export const fetchStatus = ({ id, lat, long, requestId }) => {
-  const userId = store.getState().settings.user_id;
   const missionId = store.getState().mission.id;
   let url = new URL(`/status`, apiRoot);
   id && url.searchParams.set('id', id);
@@ -12,33 +11,37 @@ export const fetchStatus = ({ id, lat, long, requestId }) => {
   long && url.searchParams.set('long', long);
   requestId && url.searchParams.set('requestId', requestId);
   missionId && url.searchParams.set('missionId', missionId);
-  url.searchParams.set('user_id', userId);
-  return fetch(url)
-    .then(response => response.json());
+  return fetchWithUserId(url);
 };
 
 export const createRequest = ({pickup, dropoff, requested_pickup_time, size, weight}) => {
-  const userId = store.getState().settings.user_id;
   pickup = getShortCoordsString(pickup, 8, ',');
   dropoff = getShortCoordsString(dropoff, 8, ',');
-  return fetch(`${apiRoot}/request/new?user_id=${userId}&pickup=${pickup}&dropoff=${dropoff}&requested_pickup_time=${requested_pickup_time}&size=${size}&weight=${weight}`)
-    .then(response => response.json());
+  let url = new URL(`/request/new`, apiRoot);
+  url.searchParams.set('pickup', pickup);
+  url.searchParams.set('dropoff', dropoff);
+  url.searchParams.set('requested_pickup_time', requested_pickup_time);
+  url.searchParams.set('size', size);
+  url.searchParams.set('weight', weight);
+  return fetchWithUserId(url);
 };
 
 export const chooseBid = (bid_id) => {
-  const userId = store.getState().settings.user_id;
   let url = new URL(`/choose_bid`, apiRoot);
-  url.searchParams.set('user_id', userId);
   url.searchParams.set('bid_id', bid_id);
-  return fetch(url)
-    .then(response => response.json());
+  return fetchWithUserId(url);
 };
 
 export const cancelRequest = () => {
   const requestId = store.getState().order.requestId;
-  const userId = store.getState().settings.user_id;
   let url = new URL(`/request/cancel`, apiRoot);
   url.searchParams.set('requestId', requestId);
+  return fetchWithUserId(url);
+};
+
+
+const fetchWithUserId = (url) => {
+  const userId = store.getState().settings.user_id;
   url.searchParams.set('user_id', userId);
   return fetch(url)
     .then(response => response.json());

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -12,7 +12,7 @@ export const fetchStatus = ({ id, lat, long, requestId }) => {
   long && url.searchParams.set('long', long);
   requestId && url.searchParams.set('requestId', requestId);
   missionId && url.searchParams.set('missionId', missionId);
-  url.searchParams.set('userId', userId);
+  url.searchParams.set('user_id', userId);
   return fetch(url)
     .then(response => response.json());
 };
@@ -36,8 +36,10 @@ export const chooseBid = (bid_id) => {
 
 export const cancelRequest = () => {
   const requestId = store.getState().order.requestId;
+  const userId = store.getState().settings.user_id;
   let url = new URL(`/request/cancel`, apiRoot);
   url.searchParams.set('requestId', requestId);
+  url.searchParams.set('user_id', userId);
   return fetch(url)
     .then(response => response.json());
 };


### PR DESCRIPTION
## Description
Now, every request to mission control uses `fetchWithUserId` which appends the user_id in the settings reducer store to the request parameters.