### PR TITLE
Changed the price variable to expect a float. Mission Control issue #86

### DIFF
--- a/src/components/VehicleBid.jsx
+++ b/src/components/VehicleBid.jsx
@@ -22,7 +22,7 @@ const VehicleBid = ({bid, vehicle, shown, chooseBid}) => {
         <dt>Estimated delivery time:</dt>
         <dd>{Math.ceil(bid.time_to_dropoff)} minutes</dd>
         <dt>Cost for delivery:</dt>
-        <dd>{bid.price} <img src={currencyImage} className="currency-symbol" alt="DAV"/></dd>
+        <dd>{bid.price.toFixed(2)} <img src={currencyImage} className="currency-symbol" alt="DAV"/></dd>
       </dl>
     </div>
   );

--- a/src/components/VehicleBid.jsx
+++ b/src/components/VehicleBid.jsx
@@ -22,7 +22,7 @@ const VehicleBid = ({bid, vehicle, shown, chooseBid}) => {
         <dt>Estimated delivery time:</dt>
         <dd>{Math.ceil(bid.time_to_dropoff)} minutes</dd>
         <dt>Cost for delivery:</dt>
-        <dd>{bid.price.toFixed(2)} <img src={currencyImage} className="currency-symbol" alt="DAV"/></dd>
+        <dd>{Math.round(bid.price * 100) / 100} <img src={currencyImage} className="currency-symbol" alt="DAV"/></dd>
       </dl>
     </div>
   );

--- a/src/reducers/mission.js
+++ b/src/reducers/mission.js
@@ -24,7 +24,7 @@ export default handleActions({
     const mission = {
       id: parseInt(mission_id),
       vehicleId: vehicle_id,
-      price: parseFloat(price),
+      price: price,
       timeToPickup: parseFloat(time_to_pickup),
       timeToDropoff: parseFloat(time_to_dropoff),
       pickup: {lat: parseFloat(pickup_lat), long: parseFloat(pickup_long) },

--- a/src/reducers/mission.js
+++ b/src/reducers/mission.js
@@ -24,7 +24,7 @@ export default handleActions({
     const mission = {
       id: parseInt(mission_id),
       vehicleId: vehicle_id,
-      price: price,
+      price: parseFloat(price),
       timeToPickup: parseFloat(time_to_pickup),
       timeToDropoff: parseFloat(time_to_dropoff),
       pickup: {lat: parseFloat(pickup_lat), long: parseFloat(pickup_long) },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The price variable in Mission Control was a string and being converted to float in Missions. I changed this so that Missions expects price to be a float already. This goes along with the change I made to mission control in this pull request https://github.com/DAVFoundation/missioncontrol/pull/108#discussion_r158684336.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/DAVFoundation/missioncontrol/issues/86

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It fixes an issue in which the price variable was a string but should be a float. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I tested by opening the app and ordering a drone. The price displays 2 decimal points unless it ends in a 0. For example something with the price 3.60 would display as 3.6. For some reason I couldn't call toFixed(2) where the price is being displayed in the UI. 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
