### PR TITLE
Fixed: Select default package size based on config file

### DIFF
--- a/src/components/OrderScreen.jsx
+++ b/src/components/OrderScreen.jsx
@@ -5,6 +5,7 @@ import { getShortCoordsString, coordsFromString } from '../lib/utils';
 import './OrderScreen.css';
 import arrow from '../images/arrow-left.svg';
 import IconSelector from './IconSelector.jsx';
+import getConfig from '../config';
 
 // icons
 import sizeLetter from '../images/size_letter.svg';
@@ -20,7 +21,7 @@ class OrderScreen extends Component {
     this.createOrderDetailsObject = this.createOrderDetailsObject.bind(this);
 
     this.state = {
-      packageSize: ''
+      packageSize: getConfig('default_package_size')
     };
 
     // Options should be read from some kind of configuration


### PR DESCRIPTION

## Description
Load the config and get the default package size and set it as default in the state.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
