### PR TITLE
focus on pickup coordinates and zoom to level 7 #55

### DIFF
--- a/src/components/Map.jsx
+++ b/src/components/Map.jsx
@@ -21,7 +21,7 @@ class Map extends Component {
     if(this.props.orderStage === 'draft' && nextProps.orderStage === 'searching') {
       initiateZoomTransition(this.map, nextProps.pickup, nextProps.pickup);
       this.map.easeTo({
-        zoom: 7,  // zoom to level 7
+        zoom: 14,   // zoom to level 14
         curve: 1.5  // speed of zoom
       });
       addTerminalPinSources(this.map);

--- a/src/components/Map.jsx
+++ b/src/components/Map.jsx
@@ -19,7 +19,11 @@ class Map extends Component {
     updateMap(this.map, nextProps.vehicles, terminals);
 
     if(this.props.orderStage === 'draft' && nextProps.orderStage === 'searching') {
-      initiateZoomTransition(this.map, nextProps.pickup, nextProps.dropoff);
+      initiateZoomTransition(this.map, nextProps.pickup, nextProps.pickup);
+      this.map.easeTo({
+        zoom: 7,  // zoom to level 7
+        curve: 1.5  // speed of zoom
+      });
       addTerminalPinSources(this.map);
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Include only pickup coordinates in the call to `initiateZoomTransition()` to focus on pickup coordinates at `/searching`.

Use `map.flyTo()` to set the zoom level to 7 and animate the zoom to this level.
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/DAVFoundation/missions/issues/55
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
