### PR TITLE
Fix/mission progress text

### DIFF
--- a/src/components/MissionScreen.jsx
+++ b/src/components/MissionScreen.jsx
@@ -41,8 +41,8 @@ class MissionScreen extends Component {
             <img src={timeIcon} alt="Time Icon"/>
           </div>
           <div className="mission-info-text">
-            <p>Estimated time to pickup location:</p>
-            <h3>3 minutes</h3>
+            <p>Estimated time to {this.props.leg} location:</p>
+            <h3>{this.props.timeLeftInLeg} {this.props.timeLeftInLeg == '1' ? 'minute': 'minutes'}</h3>
           </div>
         </div>
       </div>) ||
@@ -61,7 +61,9 @@ class MissionScreen extends Component {
 }
 
 MissionScreen.propTypes = {
-  vehicleStatus: PropTypes.string
+  vehicleStatus: PropTypes.string,
+  leg: PropTypes.string,
+  timeLeftInLeg: PropTypes.string
 };
 
 

--- a/src/containers/MissionContainer.jsx
+++ b/src/containers/MissionContainer.jsx
@@ -4,12 +4,35 @@ import { getVehicleArray } from '../reducers/vehicles';
 
 const matchStateToProps = (state) => {
   const vehicles = getVehicleArray(state.vehicles);
+  const mission = state.mission;
   let props = {};
   if (vehicles[0]){
+    const leg = vehicles[0].status.split('_')[1];
     props.vehicleStatus = vehicles[0].status;
+    props.leg = leg;
+    let timeLeftInLeg;
+    switch (leg) {
+    case 'dropoff': {
+      const travellingDropoffAt = parseInt(mission.travelling_dropoff_at);
+      const timeToDropoff = parseInt(mission.time_to_dropoff);
+      timeLeftInLeg = (travellingDropoffAt + timeToDropoff - Date.now())/60000;
+      break;
+    }
+    case 'pickup': {
+      const vehicleSignedAt = parseInt(mission.vehicle_signed_at);
+      const timeToPickup = parseInt(mission.time_to_pickup);
+      timeLeftInLeg = (vehicleSignedAt + timeToPickup - Date.now())/60000;
+      break;
+    }
+    }
+    timeLeftInLeg = timeLeftInLeg ? timeLeftInLeg.toFixed(0) : '0';
+    props.timeLeftInLeg = timeLeftInLeg;
   }
+
   return props;
 };
+
+
 
 export default connect(
   matchStateToProps,

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -29,7 +29,9 @@ export const humanReadableVehicleStatus = {
   waiting_pickup: 'Waiting for Takeoff confirmation',
   takeoff_pickup: 'Taking off',
   travelling_dropoff: 'Flying to Dropoff',
-  waiting_dropoff: 'Waiting at Dropoff'
+  landing_dropoff: 'Landing at Dropoff',
+  waiting_dropoff: 'Waiting at Dropoff',
+  available: 'Completed'
 };
 
 const randomShift = () => {


### PR DESCRIPTION
**Fixes these issues**

1. The text "estimated time to pickup location" used to always be shown, now it changes depending on the current leg of the mission.

2. Estimated time now shows the correct estimates in minutes.

3. Mission status text no longer shows up as blank string