### PR TITLE
refactor: cleaned up render() method of MissionScreen

### DIFF
--- a/src/components/MissionScreen.jsx
+++ b/src/components/MissionScreen.jsx
@@ -25,36 +25,40 @@ class MissionScreen extends Component {
   }
 
   render() {
-    if ( this.state.missionComplete ){
-      return (<div className="mission-info">
-        <div className="mission-info-summary">
-          <h1>Delivery completed successfully</h1>
-          <p>Cost for delivery:</p>
-          <h1>20 <img src={currencyImage} className="currency-symbol" alt="DAV"/></h1>
-          <Link to="/" className="big-button close">Close</Link>
-        </div>
-      </div>);
-    }else{
-      return (<div className="mission-info">
-        <div className="mission-info-container">
-          <div className="mission-info-icon">
-            <img src={gpsPointIcon} alt="GPS Point Icon"/>
-          </div>
-          <div className="mission-info-text">
-            <p>Current State:</p>
-            <h3>{humanReadableVehicleStatus[this.props.vehicleStatus]}</h3>
+    if (this.state.missionComplete) {
+      return (
+        <div className="mission-info">
+          <div className="mission-info-summary">
+            <h1>Delivery completed successfully</h1>
+            <p>Cost for delivery:</p>
+            <h1>20 <img src={currencyImage} className="currency-symbol" alt="DAV"/></h1>
+            <Link to="/" className="big-button close">Close</Link>
           </div>
         </div>
-        <div className="mission-info-container">
-          <div className="mission-info-icon">
-            <img src={timeIcon} alt="Time Icon"/>
+      );
+    } else {
+      return (
+        <div className="mission-info">
+          <div className="mission-info-container">
+            <div className="mission-info-icon">
+              <img src={gpsPointIcon} alt="GPS Point Icon"/>
+            </div>
+            <div className="mission-info-text">
+              <p>Current State:</p>
+              <h3>{humanReadableVehicleStatus[this.props.vehicleStatus]}</h3>
+            </div>
           </div>
-          <div className="mission-info-text">
-            <p>Estimated time to {this.props.leg} location:</p>
-            <h3>{parseFloat(this.props.timeLeftInLeg) > 1 ? `${this.props.timeLeftInLeg} minutes` : 'less than a minute'}</h3>
+          <div className="mission-info-container">
+            <div className="mission-info-icon">
+              <img src={timeIcon} alt="Time Icon"/>
+            </div>
+            <div className="mission-info-text">
+              <p>Estimated time to {this.props.leg} location:</p>
+              <h3>{parseFloat(this.props.timeLeftInLeg) > 1 ? `${this.props.timeLeftInLeg} minutes` : 'less than a minute'}</h3>
+            </div>
           </div>
         </div>
-      </div>);
+      );
     }
   }
 }
@@ -64,6 +68,5 @@ MissionScreen.propTypes = {
   leg: PropTypes.string,
   timeLeftInLeg: PropTypes.string
 };
-
 
 export default MissionScreen;

--- a/src/components/MissionScreen.jsx
+++ b/src/components/MissionScreen.jsx
@@ -25,8 +25,17 @@ class MissionScreen extends Component {
   }
 
   render() {
-    return (
-      !this.state.missionComplete && (<div className="mission-info">
+    if ( this.state.missionComplete ){
+      return (<div className="mission-info">
+        <div className="mission-info-summary">
+          <h1>Delivery completed successfully</h1>
+          <p>Cost for delivery:</p>
+          <h1>20 <img src={currencyImage} className="currency-symbol" alt="DAV"/></h1>
+          <Link to="/" className="big-button close">Close</Link>
+        </div>
+      </div>);
+    }else{
+      return (<div className="mission-info">
         <div className="mission-info-container">
           <div className="mission-info-icon">
             <img src={gpsPointIcon} alt="GPS Point Icon"/>
@@ -45,19 +54,9 @@ class MissionScreen extends Component {
             <h3>{parseFloat(this.props.timeLeftInLeg) > 1 ? `${this.props.timeLeftInLeg} minutes` : 'less than a minute'}</h3>
           </div>
         </div>
-      </div>) ||
-      this.state.missionComplete && (<div className="mission-info">
-        <div className="mission-info-summary">
-          <h1>Delivery completed successfully</h1>
-          <p>Cost for delivery:</p>
-          <h1>20 <img src={currencyImage} className="currency-symbol" alt="DAV"/></h1>
-          <Link to="/" className="big-button close">Close</Link>
-        </div>
-      </div>)
-    );
+      </div>);
+    }
   }
-
-
 }
 
 MissionScreen.propTypes = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The render() method of MissionScreen (https://github.com/DAVFoundation/missions/blob/master/src/components/MissionScreen.jsx#L29) uses an && after the return and is quite confusing.

Refactored the render to be more like:

```
render() {
if (!this.state.missionComplete)
{ return (<div className="mission-info">...) }
else
{ return ... }
}
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
visually tested after the change.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 