### PR TITLE
refs #33 include hash of file contents in bundled files

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -22,7 +22,7 @@ module.exports = (env = 'development') => {
     output: {
       path: path.resolve(__dirname, 'dist'),
       publicPath: '/',
-      filename: '[name].bundle.js',
+      filename: '[name].bundle.[chunkhash:8].js',
       sourceMapFilename: '[file].map',
     },
     module: {
@@ -65,7 +65,7 @@ module.exports = (env = 'development') => {
     plugins: [
       new webpack.optimize.CommonsChunkPlugin({
         name: 'vendor',
-        filename: 'vendor.bundle.js',
+        filename: 'vendor.bundle.[chunkhash:8].js',
       }),
     ],
   };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Include hash of file contents in bundled files. 
- Browser will always get the latest version and not the cached version of the file. 
- Support long term caching

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Solving : #33 (Update webpack to include a hash of the file contents in the bundled files' names)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Long term caching can be enabled with this and at the same time ensure that if file is changed, browser always gets the latest copy. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Tested with build locally. 
- Tested with / without changing file contents. (If file content is not changed, hash is same)

## Screenshots (if appropriate):
![screenshot from 2018-02-18 17-53-27](https://user-images.githubusercontent.com/29228904/36350839-0fbd69c8-14da-11e8-90b0-4c965ae49742.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
