### PR TITLE
Hide route pins after mission complete #89

### DIFF
--- a/src/components/Map.jsx
+++ b/src/components/Map.jsx
@@ -23,6 +23,10 @@ class Map extends Component {
       addTerminalPinSources(this.map);
     }
 
+    if(this.props.missionStatus === 'completed' && nextProps.orderStage === 'draft') {
+      clearPins(this.map);
+    }
+
     if(['searching', 'choosing', 'signing'].includes(this.props.orderStage) && nextProps.orderStage === 'draft') {
       clearPins(this.map);
     } else {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When a mission is completed the pins showing the dropoff and pickup location are still visible when the user routes to the homepage. This pull request fixes that

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#89 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Pins should only be visible when a mission is in progress.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
* Complete a mission
* Click on the `Complete` button that routes to the homepage
* Notice the pins are no longer visible.


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project.
- [x ] My change requires a change to the documentation.
- [x ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x ] All new and existing tests passed.
