### PR TITLE
#94 Show drone's starting location on map

### DIFF
--- a/src/components/Map.jsx
+++ b/src/components/Map.jsx
@@ -34,11 +34,21 @@ class Map extends Component {
     }
 
     if (nextProps.orderStage === 'in_mission') {
-      initiateZoomTransition(this.map, nextProps.pickup, nextProps.dropoff);
-      if (this.props.vehicles.length > 0 && nextProps.vehicles[0].status === 'waiting_pickup') {
-        this.props.history.push(this.props.appPath+'/confirm-takeoff');
-      } else {
-        this.props.history.push(this.props.appPath+'/mission');
+      if (this.props.vehicles.length > 0) {
+
+        if (nextProps.vehicles[0].status === 'waiting_pickup') {
+          this.props.history.push(this.props.appPath+'/confirm-takeoff');
+        } else {
+          this.props.history.push(this.props.appPath+'/mission');
+        }
+
+        if (nextProps.vehicles[0].status === 'travelling_pickup') {
+          initiateZoomTransition(this.map, nextProps.vehicles[0].coords, nextProps.pickup, { maxZoom: 18 });
+        }
+
+        if (nextProps.vehicles[0].status === 'travelling_dropoff') {
+          initiateZoomTransition(this.map, nextProps.pickup, nextProps.dropoff);
+        }
       }
     }
 


### PR DESCRIPTION
## Description
When the drone is en-route package pickup location, `initiateZoomTransition` is called on the drone's location and the pickup location, and when the drone's en-route dropoff location, the `initiateZoomTransition` is again called but this time on `pickup` and `dropoff` location.

## Related Issue
https://github.com/DAVFoundation/missions/issues/94

## Motivation and Context
User's want to be able to see the drone while it's on its way to pick up the package.

## How Has This Been Tested?
- Created an order and watched the camera change focus to the drone while it moved to the pickup location.
- Ran tests and made sure existing tests still passed

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/15184445/36490465-98879472-1728-11e8-83a6-4972e44d91be.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
