### PR TITLE
Added 100 MS Delay to Sorting Option

### DIFF
--- a/src/components/BidSelectionHeader.jsx
+++ b/src/components/BidSelectionHeader.jsx
@@ -54,9 +54,14 @@ class BidSelectionHeader extends Component {
     this.props.handleSortingOptionChange(e.target.title);
 
     this.setState({
-      sortOptionSelected: e.target.title,
-      sortOptionsOpen: !this.state.sortOptionsOpen
+      sortOptionSelected: e.target.title
     });
+      
+    setTimeout(() => {
+      this.setState({
+        sortOptionsOpen: !this.state.sortOptionsOpen
+      });
+    }, 100); 
   }
 
   render() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added a 100ms timer to the sortOptionsOpen state, so that the drop-down window now closes after a short delay, allowing the user to see their chosen Option. As an aside could potentially extend the delay to 150 or 200ms, as 100 still feels too quick.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Issue #90 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Change required at request from maintainers.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
In terminal code compilation test passes.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
