### PR TITLE
Properly disable Find Drones buttons

### DIFF
--- a/src/components/OrderScreen.jsx
+++ b/src/components/OrderScreen.jsx
@@ -150,7 +150,7 @@ class OrderScreen extends Component {
         </div>
         <Link
           to="/searching"
-          className={(this.state.pickup !== undefined  && this.state.dropoff !== undefined) ? 'big-button form-submit-button': 'disabled-button form-submit-button'}
+          className={(this.state.pickup !== undefined && this.state.pickup.location !== undefined && this.state.dropoff !== undefined) ? 'big-button form-submit-button': 'disabled-button form-submit-button'}
           onClick={this.submitForm}
           disabled
         >

--- a/src/components/OrderScreen.jsx
+++ b/src/components/OrderScreen.jsx
@@ -87,7 +87,11 @@ class OrderScreen extends Component {
           <Geosuggest
             type="text"
             id="pickup-location"
+            ignoreTab={true}
             placeholder="Type the address of the pickup location"
+            onChange={
+              () => this.setState({ pickup: undefined })
+            }
             onSuggestSelect={
               geo => {
                 if (geo) {
@@ -102,7 +106,11 @@ class OrderScreen extends Component {
           <Geosuggest
             type="text"
             id="dropoff-location"
+            ignoreTab={true}
             placeholder="Type the address of the dropoff location"
+            onChange={
+              () => this.setState({ dropoff: undefined })
+            }
             onSuggestSelect={
               geo => {
                 if (geo) {


### PR DESCRIPTION
Disable Find Drones button when either pickup or dropoff locations are empty
Fixes #106

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
I changed the Find Drones button class conditions so it also checks if the pickup.location is undefined, since the pickup state takes the entire geo object
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#106 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It needed to be fixed because "if the user selects an address both for the pickup and dropoff making the button enabled and then removed the selection at one or both of those - the button remains active - leading to an incorrect application state."
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I tested it by redoing the problem conditions
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
