### PR TITLE
update size_can icon from blue to red #119

### DIFF
--- a/src/images/size_can.svg
+++ b/src/images/size_can.svg
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg width="18px" height="21px" viewBox="0 0 18 21" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <!-- Generator: Sketch 47 (45396) - http://www.bohemiancoding.com/sketch -->
+    <!-- Generator: Sketch 49.1 (51147) - http://www.bohemiancoding.com/sketch -->
     <title>soda</title>
     <desc>Created with Sketch.</desc>
     <defs></defs>
     <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g id="Order-Pick-Up-screen" transform="translate(-119.000000, -290.000000)" stroke="#777FF9">
-            <g id="soda" transform="translate(119.000000, 290.000000)">
+        <g id="Order-Pick-Up-screen" transform="translate(-119.000000, -287.000000)" stroke="#FE6B48">
+            <g id="soda" transform="translate(119.000000, 287.000000)">
                 <path d="M1.80825944,3.3 L4.400029,20.5 L13.674878,20.5 L16.1941575,3.3 L1.80825944,3.3 Z" id="Rectangle-5"></path>
                 <path d="M0.792759891,0.5 L2.22497758,3.5 L15.8086519,3.5 L17.2137033,0.5 L0.792759891,0.5 Z" id="Rectangle-5" transform="translate(9.000000, 2.000000) scale(1, -1) translate(-9.000000, -2.000000) "></path>
-                <path d="M15.943679,6.81146484 L2.06634274,6.81146484" id="Path-4"></path>
-                <path d="M14.5227273,16.2614648 L3.47727273,16.2614648" id="Path-4"></path>
+                <path d="M15.943679,6.81146484 L2.06634274,6.81146484" id="Path-4" fill="#FFFFFF"></path>
+                <path d="M14.5227273,16.2614648 L3.47727273,16.2614648" id="Path-4" fill="#FFFFFF"></path>
             </g>
         </g>
     </g>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Updated size_can icon from blue to red as per issue #119 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
ran http://localhost:3333/ to make sure that the color has been changed from blue to red.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
