### PR TITLE
refactored variable names for adding and removing terminals

### DIFF
--- a/src/components/Map.jsx
+++ b/src/components/Map.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { createMap, updateMap, initiateZoomTransition, clearPins, addTerminalPinSources} from '../lib/map';
+import { createMap, updateMap, initiateZoomTransition, clearTerminals, addTerminals} from '../lib/map';
 import './Map.css';
 
 class Map extends Component {
@@ -20,17 +20,17 @@ class Map extends Component {
 
     if(this.props.orderStage === 'draft' && nextProps.orderStage === 'searching') {
       initiateZoomTransition(this.map, nextProps.pickup, nextProps.pickup,{maxZoom:14});
-      addTerminalPinSources(this.map);
+      addTerminals(this.map);
     }
 
     if (nextProps.missionStatus === 'completed') {
-      clearPins(this.map);
+      clearTerminals(this.map);
     }
 
     if(['searching', 'choosing', 'signing'].includes(this.props.orderStage) && nextProps.orderStage === 'draft') {
-      clearPins(this.map);
+      clearTerminals(this.map);
     } else {
-      addTerminalPinSources(this.map);
+      addTerminals(this.map);
     }
 
     if (nextProps.orderStage === 'in_mission') {

--- a/src/lib/map.js
+++ b/src/lib/map.js
@@ -158,7 +158,7 @@ export const initiateZoomTransition = (map, pickup, dropoff,options) => {
   });
 };
 
-export const clearPins = map => {
+export const clearTerminals = map => {
   if (map.getSource('pickup') && map.getSource('dropoff')){
     map.removeLayer('pickup');
     map.removeLayer('dropoff');
@@ -167,7 +167,7 @@ export const clearPins = map => {
   }
 };
 
-export const addTerminalPinSources = map => {
+export const addTerminals = map => {
   if (!map.getSource('pickup') && !map.getSource('dropoff')) {
     map.addSource('pickup', {
       type: 'geojson',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Refactored the name for functions `clearPins` and `addTerminalPinSources` to `clearTerminals` and `addTerminals`

## Description
<!--- Describe your changes in detail -->
```js
    const terminals = {
      pickup: nextProps.pickup,
      dropoff: nextProps.dropoff
    };
```
The above code shows that terminals include both pickup and dropoff locations. 
`clearPins` is actually removing the pickup and dropoff layers from the map so renamed it to `clearTerminals` and `addTerminalPinSources` is basically adding pickup and dropoff layers to map so refactored it to `addTerminals`.

@srfrnk @liorshkoori  Please feel free to correct me if I understood it wrong. 🙂 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I made the changes and re ran the project and able to see the same funcitonality working and npm test is also happy! 
