### PR TITLE
write tests for shiftCoords function

### DIFF
--- a/test/specs/lib.utils.spec.js
+++ b/test/specs/lib.utils.spec.js
@@ -4,25 +4,10 @@ import * as utils from '../../src/lib/utils';
 describe('shiftCoords function', () => {
 
   const coordinates = { lat: 19.14641, long: 73.1424 };
-  let shiftCoordsSpy;
 
-  beforeAll(() => {
-    shiftCoordsSpy = jest.spyOn(utils, 'shiftCoords');
-  });
-
-  afterAll(() => {
-    shiftCoordsSpy.mockClear();
-  });
-
-  it('should receive one object', () => {
-    utils.shiftCoords(coordinates);
-    expect(shiftCoordsSpy.mock.calls[0].length).toBe(1);
-    expect(typeof shiftCoordsSpy.mock.calls[0][0]).toBe('object');
-  });
-
-  it('input object should be a coordinate', () => {
-    utils.shiftCoords(coordinates);
-    expect(Object.keys(shiftCoordsSpy.mock.calls[0][0])).toEqual(expect.arrayContaining(['lat', 'long']));
+  it('return undefined if input object is not a coordinate', () => {
+    const output = utils.shiftCoords({ other : 'than', a : 'coordinate' });
+    expect(output).toEqual(undefined);
   });
 
   it('should return one object', () => {

--- a/test/specs/lib.utils.spec.js
+++ b/test/specs/lib.utils.spec.js
@@ -1,0 +1,38 @@
+import * as utils from '../../src/lib/utils';
+
+
+describe('shiftCoords function', () => {
+
+  const coordinates = { lat: 19.14641, long: 73.1424 };
+  let shiftCoordsSpy;
+
+  beforeAll(() => {
+    shiftCoordsSpy = jest.spyOn(utils, 'shiftCoords');
+  });
+
+  afterAll(() => {
+    shiftCoordsSpy.mockClear();
+  });
+
+  it('should receive one object', () => {
+    utils.shiftCoords(coordinates);
+    expect(shiftCoordsSpy.mock.calls[0].length).toBe(1);
+    expect(typeof shiftCoordsSpy.mock.calls[0][0]).toBe('object');
+  });
+
+  it('input object should be a coordinate', () => {
+    utils.shiftCoords(coordinates);
+    expect(Object.keys(shiftCoordsSpy.mock.calls[0][0])).toEqual(expect.arrayContaining(['lat', 'long']));
+  });
+
+  it('should return one object', () => {
+    const output = utils.shiftCoords(coordinates);
+    expect(typeof output).toBe('object');
+  });
+  
+  it('return object should be a coordinate', () => {
+    const output = utils.shiftCoords(coordinates);
+    expect(Object.keys(output)).toEqual(expect.arrayContaining(['lat', 'long']));
+  });
+
+});


### PR DESCRIPTION
write tests for shiftCoords in utils.

## Description
created file test/specs/lib.utils.spec.js and wrote test cases for shiftCoords. which is covering all below cases.

- [x] should receive one object
- [x] input object should be a coordinate
- [x] should return one object
- [x] return object should be a coordinate 

## Related Issue
issue #150 

## Motivation and Context
As a project that relies on a large community of contributors, it is very important for us to have good tests to make sure changes don't break anything.

## How Has This Been Tested?
using `npm test` command.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
