### PR TITLE
change confirm text color in takeoff page #163

### DIFF
--- a/src/common.css
+++ b/src/common.css
@@ -101,7 +101,7 @@ h1 {
 
 .alert-button-confirm {
   border-bottom-right-radius: 5px;
-  color: #2BCA81;
+  color: #FF6A46;
 }
 
 .big-button {


### PR DESCRIPTION
Changed confirm text color in takeoff page

## Description
Changed confirm text color to #FF6A46

## Related Issue
#163 

## Motivation and Context
At DAV we are currently re designing our branding. According to the new design we are changing the color scheme of all our applications including missions.

## How Has This Been Tested?
The color is the required color.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/17077365/38211473-2cfe3ad6-3680-11e8-86ad-89231b4bf81c.png)

## Types of changes
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
