### PR TITLE
fix: support 0 values in cords

### DIFF
--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -28,7 +28,9 @@ export const getShortCoordsString = (
 ) => {
   const { lat, long } = coords;
   return (
-    lat && long && lat.toFixed(precision) + separator + long.toFixed(precision)
+    (lat || lat === 0) &&
+    (long || long === 0) &&
+    `${lat.toFixed(precision)}${separator}${long.toFixed(precision)}`
   );
 };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

return `0` with the requested float precision when one of the value of coords is 0.

## Description

Again, this function is not being used anywhere, Might be in future. I just happened to notice some thing we can improve on and made the changes. Inspired by the comment on this pr https://github.com/DAVFoundation/missions/pull/151

## Motivation and Context

Previously, if one of the corrds is `0` it will return just `0` instead of `0, 32.234000`
Now it will return `0.000000, 32.234000`. 

@TalAter, Let me know if you got any feedback! 